### PR TITLE
feat: add extended env var support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ semantic-release plugin to publish a python package to PyPI
 
 ## Environment variables
 
-| Variable | Description
-| -------- | -----------
-| ```PYPI_TOKEN``` | [API token](https://test.pypi.org/help/#apitoken) for PyPI
+| Variable | Description | Required | Default
+| -------- | ----------- | ----------- | -----------
+| ```PYPI_TOKEN``` | [API token](https://test.pypi.org/help/#apitoken) for PyPI | true | 
+| ```PYPI_USERNAME``` | Username for PyPI | false | ```__token__```
+| ```PYPI_REPO_URL``` | Repo URL for PyPI | false | See [Options](#options)
 
 ## Usage
 

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -14,7 +14,7 @@ async function publishPackage(setupPy, distDir, repoUrl){
             '--skip-existing',
             `${distDir}/*`
         ], {cwd: path.dirname(setupPy), env: {
-            TWINE_USERNAME: '__token__',
+            TWINE_USERNAME: process.env['PYPI_USERNAME'] ? process.env['PYPI_USERNAME'] : '__token__',
             TWINE_PASSWORD: process.env['PYPI_TOKEN']
         }})
     } catch(err){
@@ -25,7 +25,7 @@ async function publishPackage(setupPy, distDir, repoUrl){
 async function publish(pluginConfig, context){
     let setupPy = getOption(pluginConfig, 'setupPy')
     let distDir = getOption(pluginConfig, 'distDir')
-    let repoUrl = getOption(pluginConfig, 'repoUrl')
+    let repoUrl = process.env['PYPI_REPO_URL'] ? process.env['PYPI_REPO_URL'] : getOption(pluginConfig, 'repoUrl')
 
     await publishPackage(setupPy, distDir, repoUrl)
 }

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -57,11 +57,11 @@ function verifyToken(token){
     }
 }
 
-async function verifyAuth(repoUrl, token){
+async function verifyAuth(repoUrl, username, token){
     let form = new FormData()
     form.append(':action', 'file_upload')
 
-    let basicAuth = Buffer.from(`__token__:${token}`).toString('base64')
+    let basicAuth = Buffer.from(`${username}:${token}`).toString('base64')
     let headers = {
         "Authorization": `Basic ${basicAuth}`,
     }
@@ -81,8 +81,9 @@ async function verifyAuth(repoUrl, token){
 
 async function verify (pluginConfig) {
     let setupPy = getOption(pluginConfig, 'setupPy')
+    let username = process.env['PYPI_USERNAME'] ? process.env['PYPI_USERNAME'] : '__token__'
     let token = process.env['PYPI_TOKEN']
-    let repoUrl = getOption(pluginConfig, 'repoUrl')
+    let repoUrl = process.env['PYPI_REPO_URL'] ? process.env['PYPI_REPO_URL'] : getOption(pluginConfig, 'repoUrl')
     
     assertEnvVar('PYPI_TOKEN')
 
@@ -90,9 +91,10 @@ async function verify (pluginConfig) {
     await assertPackage('wheel')
     await assertPackage('twine')
 
-    verifyToken(token)
+    // Skip verification because of custom pypi repos
+    // verifyToken(token)
     await verifySetupPy(setupPy)
-    await verifyAuth(repoUrl, token)
+    await verifyAuth(repoUrl, username, token)
 }
 
 module.exports = {

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -55,9 +55,9 @@ test('test verifySetupPy', async() => {
 test('test verifyAuth', async() => {
     let repoUrl = 'https://test.pypi.org/legacy/'
     
-    await expect(verifyAuth(repoUrl, '12345')).rejects.toThrow()
+    await expect(verifyAuth(repoUrl, '__token__', '12345')).rejects.toThrow()
     if(process.env['TESTPYPI_TOKEN']){
-        await expect(verifyAuth(repoUrl, process.env['TESTPYPI_TOKEN'])).resolves.toBe(undefined)
+        await expect(verifyAuth(repoUrl, '__token__', process.env['TESTPYPI_TOKEN'])).resolves.toBe(undefined)
     }
     else {
         console.warn('skipped verifyAuth because TESTPYPI_TOKEN is not set')


### PR DESCRIPTION
Hey,

I use GitLab for my PyPi packages and therefore I needed to customise the `TWINE_USERNAME` and `repoUrl`. I prefer to use environment variables for this use case because I then can do something like this:

```yaml
variables:
  PYPI_TOKEN: ${CI_JOB_TOKEN}
  PYPI_USERNAME: gitlab-ci-token
  PYPI_REPO_URL: $CI_API_V4_URL/projects/$CI_PROJECT_ID/packages/pypi
```

To achieve this behavior, I added support for two new environment variables:
- `PYPI_USERNAME`
- `PYPI_REPO_URL`

In addition, I also updated the README file and mentioned the new configuration options.

**IMPORTANT:** To use GitLab as my PyPi Repo, I disabled the prefix check. Additionally, I think this check is also for the main PyPi repo not necessary because the verify function checks if login to the repo succeeds.