### PR TITLE
fix(verify): improve version check

### DIFF
--- a/lib/verify.js
+++ b/lib/verify.js
@@ -33,22 +33,15 @@ async function assertPackage(name){
     }
 }
 
-const versionRe = /version[^\n]+,/
-
-function verifySetupPy(setupPy){
-    
-    return new Promise((resolve, reject) => {
-        fs.readFile(setupPy, (err, data) => {
-            if(err){
-                reject(err)
-            }
-            
-            if(versionRe.test(data)){
-                reject(Error(`version in ${setupPy}`))
-            }
-            resolve()
-        })
-    })
+async function verifySetupPy(setupPy){
+    try {
+        await execa('python', [
+            path.resolve(__dirname, 'verifySetup.py'),
+            path.basename(setupPy)
+        ], {cwd: path.dirname(setupPy)})
+    } catch(err){
+        throw Error(`version in ${setupPy}`)
+    }
 }
 
 async function verifyAuth(repoUrl, username, token){

--- a/lib/verifySetup.py
+++ b/lib/verifySetup.py
@@ -1,0 +1,22 @@
+import setuptools
+from unittest.mock import Mock
+import sys, os
+import argparse
+import importlib
+
+parser = argparse.ArgumentParser(description='Check if version is set inside setup.py')
+parser.add_argument('setup_path', type=str, default="./setup.py", help="path of setup.py")
+args = parser.parse_args()
+
+sys.path.insert(0, os.path.dirname(args.setup_path))
+
+mock = Mock()
+setuptools.setup = mock
+
+#import setup
+importlib.import_module(os.path.splitext(os.path.basename(args.setup_path))[0])
+
+if mock.call_args is not None and 'version' in mock.call_args[1]:
+    sys.exit(1)
+
+sys.exit(0)


### PR DESCRIPTION
Fix: #15 

@paddatrapper, I removed the regex. The version check is now done with a python script.
The script mocks `setuptools.setup`, imports setup.py and checks if the version keyword was used.

Would you like to review the changes?