### PR TITLE
feat: add support for gpg package signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ An example using Github Actions can be found in the repo [semantic-release-pypi-
 | ```distDir``` | str | ```dist``` | directory to put the source distribution archive(s) in, relative to the directory of ```setup.py```
 | ```repoUrl``` | str | ```https://upload.pypi.org/legacy/``` | The repository (package index) to upload the package to.
 | ```pypiPublish``` | bool | ```true``` | Whether to publish the python package to the pypi registry. If false the package version will still be updated.
+| ```gpgSign``` | bool | ```false``` | Whether to sign the package using GPG. A valid PGP key must already be installed and configured on the host.
+| ```gpgIdentity``` | str | ```null``` | When ```gpgSign``` is true, set the GPG identify to use when signing files. Leave empty to use the default identity.
 
 ## Development
 

--- a/lib/defaultOptions.js
+++ b/lib/defaultOptions.js
@@ -2,5 +2,7 @@ module.exports = {
     setupPy: './setup.py',
     distDir: 'dist',
     repoUrl: 'https://upload.pypi.org/legacy/',
-    pypiPublish: true
+    pypiPublish: true,
+    gpgSign: false,
+    gpgIdentity: null
 }

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -2,7 +2,7 @@ const execa = require('execa')
 const { getOption } = require('./util')
 const path = require('path')
 
-function publishPackage(setupPy, distDir, repoUrl){
+function publishPackage(setupPy, distDir, repoUrl, gpgSign, gpgIdentity){
     return execa('python', [
         '-m',
         'twine',
@@ -12,8 +12,11 @@ function publishPackage(setupPy, distDir, repoUrl){
         '--non-interactive',
         '--skip-existing',
         '--verbose',
+        gpgSign ? '--sign' : null,
+        gpgSign && gpgIdentity ? '--identity' : null,
+        gpgSign && gpgIdentity ? gpgIdentity : null,
         `${distDir}/*`
-    ], {cwd: path.dirname(setupPy), env: {
+    ].filter(arg => arg !== null), {cwd: path.dirname(setupPy), env: {
         TWINE_USERNAME: process.env['PYPI_USERNAME'] ? process.env['PYPI_USERNAME'] : '__token__',
         TWINE_PASSWORD: process.env['PYPI_TOKEN']
     }})
@@ -24,10 +27,12 @@ async function publish(pluginConfig, { logger, stdout, stderr }){
     let distDir = getOption(pluginConfig, 'distDir')
     let pypiPublish = getOption(pluginConfig, 'pypiPublish')
     let repoUrl = process.env['PYPI_REPO_URL'] ? process.env['PYPI_REPO_URL'] : getOption(pluginConfig, 'repoUrl')
+    let gpgSign = getOption(pluginConfig, 'gpgSign')
+    let gpgIdentity = getOption(pluginConfig, 'gpgIdentity')
 
     if (pypiPublish !== false) {
         logger.log(`Publishing package to ${repoUrl}`)
-        let result = publishPackage(setupPy, distDir, repoUrl)
+        let result = publishPackage(setupPy, distDir, repoUrl, gpgSign, gpgIdentity)
         result.stdout.pipe(stdout, {end: false})
         result.stderr.pipe(stderr, {end: false})
         await result;


### PR DESCRIPTION
This adds support for the `--sign` and `--identity` twine parameters, which allows for signing the package with GPG. The default is `false` so it will have the same behavior as before, unless you explicitly enable the option. The identity is also null by default and is optional.