### PR TITLE
feat: add support for releasing channels

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -41,7 +41,7 @@ async function prepare(pluginConfig, { nextRelease, logger }){
     let distDir = getOption(pluginConfig, 'distDir')
     let pypiPublish = getOption(pluginConfig, 'pypiPublish')
 
-    let version = await normalizeVersion(nextRelease.version)
+    let version = await normalizeVersion(nextRelease.version, nextRelease.version)
 
     logger.log(`Set version to ${version}`)    
     await setReleaseVersion(setupPy, version)

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -41,7 +41,7 @@ async function prepare(pluginConfig, { nextRelease, logger }){
     let distDir = getOption(pluginConfig, 'distDir')
     let pypiPublish = getOption(pluginConfig, 'pypiPublish')
 
-    let version = await normalizeVersion(nextRelease.version, nextRelease.version)
+    let version = await normalizeVersion(nextRelease.version, nextRelease.channel)
 
     logger.log(`Set version to ${version}`)    
     await setReleaseVersion(setupPy, version)

--- a/lib/util.js
+++ b/lib/util.js
@@ -6,11 +6,12 @@ function getOption(pluginConfig, option){
     return Object.prototype.hasOwnProperty.call(pluginConfig, option) ? pluginConfig[option] : defaultOptions[option]
 }
 
-async function normalizeVersion(version){
+async function normalizeVersion(version, channel=null){
+    let versionWithChannel = channel ? `${version}+${channel}` : version
     const { stdout } = await execa('python', [
         '-c',
         'import pkg_resources\n' +
-        `print(pkg_resources.packaging.version.Version('${version}'))`
+        `print(pkg_resources.packaging.version.Version('${versionWithChannel}'))`
     ])
     return stdout
 }

--- a/test/package.test.js
+++ b/test/package.test.js
@@ -26,6 +26,24 @@ test('test semantic-release-pypi', async() => {
 
 }, 30000)
 
+test('test semantic-release-pypi with channel', async() => {
+    if(!process.env['TESTPYPI_TOKEN']) {
+        console.warn('skipped test semantic-release-pypi because TESTPYPI_TOKEN is not set')
+        return
+    }
+    process.env['PYPI_TOKEN'] = process.env['TESTPYPI_TOKEN']
+    let {config, context, packageName} = await genPluginArgs(packageDir + '/default/setup.py', 'integration', 'next') // Channel is 'next'
+
+    await verifyConditions(config, context)
+    await prepare(config, context)
+    await publish(config, context)
+
+    let versionToRelease = `${context.nextRelease.version}+${context.nextRelease.channel}`
+    let res = await hasPackage('https://test.pypi.org', packageName, versionToRelease)
+    expect(res).toBe(true)
+
+}, 30000)
+
 test('test semantic-release-pypi with pypiPublish unset', async() => {
     let {config, context} = await genPluginArgs(packageDir + '/private/setup.py', 'private')
     config.pypiPublish = false

--- a/test/util.js
+++ b/test/util.js
@@ -40,7 +40,7 @@ async function hasPackage(repoUrl, packageName, version){
  * @param {string} setupPy path of setup.py
  * @returns {{config: object, context: object, packageName: string}} 
  */
- async function genPluginArgs(setupPy, name='integration'){
+ async function genPluginArgs(setupPy, name='integration', channel=null){
     let packageName = `semantic-release-pypi-${name}-test-`+uuidv4()
 
     let config = {
@@ -50,7 +50,8 @@ async function hasPackage(repoUrl, packageName, version){
 
     let context = {
         nextRelease: {
-            version: '1.2.3'
+            version: '1.2.3',
+            channel,
         },
         logger: {
             log: jest.fn()

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -29,5 +29,8 @@ test('test normalizeVersion', async() => {
     await expect(normalizeVersion('1.0.1-next')).rejects.toThrow()
     await expect(normalizeVersion('1.0.1-develop')).rejects.toThrow()
 
+    await expect(normalizeVersion('1.0.1', 'next')).resolves.toBe('1.0.1+next')
+    await expect(normalizeVersion('1.0.1', 'develop')).resolves.toBe('1.0.1+develop')
+
     await expect(normalizeVersion('1 2 3')).rejects.toThrow()
 })

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -31,6 +31,8 @@ test('test normalizeVersion', async() => {
 
     await expect(normalizeVersion('1.0.1', 'next')).resolves.toBe('1.0.1+next')
     await expect(normalizeVersion('1.0.1', 'develop')).resolves.toBe('1.0.1+develop')
+    await expect(normalizeVersion('1.0.1', 'develop_new')).resolves.toBe('1.0.1+develop.new')
+    await expect(normalizeVersion('1.0.1', 'develop-new')).resolves.toBe('1.0.1+develop.new')
 
     await expect(normalizeVersion('1 2 3')).rejects.toThrow()
 })


### PR DESCRIPTION
Channel should exist on `nextRelease` if it is set https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#channel
This PR appends the channel to the pypi version with a `+`

For example:
```
{
  branches: [
    { name: "next", channel: "next" },
  ];
}
```
Will produce a version like `1.0.0+next`