### PR TITLE
Upgrade twine to resolve issue with importlib-metadata

### DIFF
--- a/lib/py/requirements.txt
+++ b/lib/py/requirements.txt
@@ -1,6 +1,6 @@
 pip~=23.2
 build~=1.0
 setuptools~=68.2
-twine~=4.0
+twine>=5.1.1,<6
 tomlkit~=0.12
 packaging~=24.0


### PR DESCRIPTION
This pull request addresses a [bug](https://github.com/pypa/twine/issues/977) stemming from twine's reliance on deprecated behavior, which was [removed from importlib-metadata](https://github.com/python/importlib_metadata/commit/a970a491b56a3bf529821ce21867af4573cf2e0d) in version 8.0.0.

The plugin currently uses twine version 4.0.2, which depends on the latest version of importlib-metadata (>= 3.6).
Consequently, it is impacted by the breaking changes introduced in importlib-metadata version 8.0.0.

This issue has been resolved in [twine version 5.1.1](https://github.com/pypa/twine/pull/1124).