### PR TITLE
Feature: allow releasing to multiple pypi repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # 📦🐍 semantic-release-pypi
+
 [semantic-release](https://semantic-release.gitbook.io/semantic-release/) plugin to publish a python package to PyPI
 
 <a href="https://www.npmjs.com/package/semantic-release-pypi">
@@ -19,7 +20,8 @@
 
 - `pyproject.toml` based (Recommended)
   - `version` will be set inside `pyproject.toml` - [PEP 621](https://peps.python.org/pep-0621/)
-  - The build backend can be specified inside `pyproject.toml` (defaults to `setuptools`) - [PEP 518](https://peps.python.org/pep-0518/)
+  - The build backend can be specified inside `pyproject.toml` (defaults
+    to `setuptools`) - [PEP 518](https://peps.python.org/pep-0518/)
 
 <br />
 
@@ -30,35 +32,37 @@
 
 ## Steps
 
-| Step | Description
-| ---- | -----------
-| ```verifyConditions``` | <ul><li>verify the environment variable ```PYPI_TOKEN```</li><li>verify ```PYPI_TOKEN``` is authorized to publish on the specified repository</li><li>check if the packages `setuptools`, `wheel` and `twine` are installed</li></ul>
-| ```prepare``` | Update the version in `pyproject.toml` (legacy: `setup.cfg`) and create the distribution packages
-| ```publish``` | Publish the python package to the specified repository (default: pypi)
+| Step                   | Description                                                                                                                                                                                                                           
+|------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+| ```verifyConditions``` | <ul><li>verify the environment variable ```PYPI_TOKEN```</li><li>verify ```PYPI_TOKEN``` is authorized to publish on the specified repository</li><li>check if the packages `setuptools`, `wheel` and `twine` are installed</li></ul> 
+| ```prepare```          | Update the version in `pyproject.toml` (legacy: `setup.cfg`) and create the distribution packages                                                                                                                                     
+| ```publish```          | Publish the python package to the specified repository (default: pypi)                                                                                                                                                                
 
 ## Environment variables
 
-| Variable | Description | Required | Default
-| -------- | ----------- | ----------- | -----------
-| ```PYPI_TOKEN``` | [API token](https://test.pypi.org/help/#apitoken) for PyPI | true | 
-| ```PYPI_USERNAME``` | Username for PyPI | false | ```__token__```
-| ```PYPI_REPO_URL``` | Repo URL for PyPI | false | See [Options](#options)
+| Variable            | Description                                                | Required | Default                 
+|---------------------|------------------------------------------------------------|----------|-------------------------
+| ```PYPI_TOKEN```    | [API token](https://test.pypi.org/help/#apitoken) for PyPI | true     |
+| ```PYPI_USERNAME``` | Username for PyPI                                          | false    | ```__token__```         
+| ```PYPI_REPO_URL``` | Repo URL for PyPI                                          | false    | See [Options](#options) 
 
 ## Usage
 
-The plugin can be configured in the [**semantic-release** configuration file](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#configuration). Here is a minimal example:
+The plugin can be configured in the [**semantic-release
+** configuration file](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#configuration).
+Here is a minimal example:
 
 ```json
 {
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    "semantic-release-pypi",
+    "semantic-release-pypi"
   ]
 }
 ```
 
-Note that this plugin modifies the version inside of `pyproject.toml` (legacy: `setup.cfg`). 
+Note that this plugin modifies the version inside of `pyproject.toml` (legacy: `setup.cfg`).
 Make sure to commit `pyproject.toml` using the `@semantic-release/git` plugin, if you want to save the changes:
 
 ```json
@@ -70,8 +74,10 @@ Make sure to commit `pyproject.toml` using the `@semantic-release/git` plugin, i
     [
       "@semantic-release/git",
       {
-          "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
-          "assets": ["pyproject.toml"]
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
+        "assets": [
+          "pyproject.toml"
+        ]
       }
     ]
   ]
@@ -79,22 +85,54 @@ Make sure to commit `pyproject.toml` using the `@semantic-release/git` plugin, i
 ```
 
 Working examples using Github Actions can be found here:
+
 - [semantic-release-pypi-pyproject](https://github.com/abichinger/semantic-release-pypi-pyproject)
 - [semantic-release-pypi-setup](https://github.com/abichinger/semantic-release-pypi-setup)
 
 ## Options
 
-| Option | Type | Default | Description
-| ------ | ---- | ------- | -----------
-| ```srcDir``` | str | ```.``` | source directory (defaults to current directory)
-| ```distDir``` | str | ```dist``` | directory to put the source distribution archive(s) in, relative to ```srcDir```
-| ```repoUrl``` | str | ```https://upload.pypi.org/legacy/``` | The repository (package index) to upload the package to.
-| ```pypiPublish``` | bool | ```true``` | Whether to publish the python package to the pypi registry. If false the package version will still be updated.
-| ```gpgSign``` | bool | ```false``` | Whether to sign the package using GPG. A valid PGP key must already be installed and configured on the host.
-| ```gpgIdentity``` | str | ```null``` | When ```gpgSign``` is true, set the GPG identify to use when signing files. Leave empty to use the default identity.
-| ```envDir``` | string \| ```false``` | ```.venv``` | directory to create the virtual environment in, if set to `false` no environment will be created
-| ```installDeps``` | bool | ```true``` | wether to automatically install python dependencies
-| ```versionCmd``` | string | ```undefined``` | Run a custom command to update the version (e.g. `hatch version ${version}`). `srcDir` is used as working directory. `versionCmd` is required if the version is set [dynamically](https://packaging.python.org/en/latest/specifications/pyproject-toml/#dynamic)
+| Option             | Type                  | Default                               | Description                                                                                                                                                                                                                                                      
+|--------------------|-----------------------|---------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+| ```srcDir```       | str                   | ```.```                               | source directory (defaults to current directory)                                                                                                                                                                                                                 
+| ```distDir```      | str                   | ```dist```                            | directory to put the source distribution archive(s) in, relative to ```srcDir```                                                                                                                                                                                 
+| ```repoUrl```      | str                   | ```https://upload.pypi.org/legacy/``` | The repository (package index) to upload the package to.                                                                                                                                                                                                         
+| ```repoUsername``` | str                   | ```__token__```                       | The repository username.                                                                                                                                                                                                                                         
+| ```repoToken```    | str                   |                                       | The repository token. It's safer to set via PYPI_TOKEN environment variable.                                                                                                                                                                                     
+| ```pypiPublish```  | bool                  | ```true```                            | Whether to publish the python package to the pypi registry. If false the package version will still be updated.                                                                                                                                                  
+| ```gpgSign```      | bool                  | ```false```                           | Whether to sign the package using GPG. A valid PGP key must already be installed and configured on the host.                                                                                                                                                     
+| ```gpgIdentity```  | str                   | ```null```                            | When ```gpgSign``` is true, set the GPG identify to use when signing files. Leave empty to use the default identity.                                                                                                                                             
+| ```envDir```       | string \| ```false``` | ```.venv```                           | directory to create the virtual environment in, if set to `false` no environment will be created                                                                                                                                                                 
+| ```installDeps```  | bool                  | ```true```                            | wether to automatically install python dependencies                                                                                                                                                                                                              
+| ```versionCmd```   | string                | ```undefined```                       | Run a custom command to update the version (e.g. `hatch version ${version}`). `srcDir` is used as working directory. `versionCmd` is required if the version is set [dynamically](https://packaging.python.org/en/latest/specifications/pyproject-toml/#dynamic) 
+
+## Publishing to multiple repositories
+
+Using `release.config.js` you can read repository credentials from environment variables and publish to multiple
+repositories.
+
+```js
+module.exports = {
+  "plugins": [
+    [
+      "semantic-release-pypi",
+      {
+          "repoUrl": process.env['REPOSITORY_1_URL'],
+          "repoUsername": process.env['REPOSITORY_1_USERNAME'],
+          "repoToken": process.env['REPOSITORY_1_TOKEN']
+      }
+    ],
+    [
+      "semantic-release-pypi",
+      {
+          "repoUrl": process.env['REPOSITORY_2_URL'],
+          "repoUsername": process.env['REPOSITORY_2_USERNAME'],
+          "repoToken": process.env['REPOSITORY_2_TOKEN']
+      }
+    ]
+  ]
+}
+
+```
 
 ## Development
 

--- a/lib/default-options.ts
+++ b/lib/default-options.ts
@@ -28,6 +28,14 @@ export class DefaultConfig {
     return this.config.repoUrl ?? 'https://upload.pypi.org/legacy/';
   }
 
+  public get repoUsername() {
+    return this.config.repoUsername ?? '__token__';
+  }
+
+  public get repoToken() {
+    return this.config.repoToken ?? '';
+  }
+
   public get pypiPublish() {
     return this.config.pypiPublish ?? true;
   }

--- a/lib/publish.ts
+++ b/lib/publish.ts
@@ -67,11 +67,6 @@ async function publish(pluginConfig: PluginConfig, context: Context) {
 
   if (pypiPublish !== false) {
     logger.log(`Publishing package to ${repoUrl}`);
-    if (process.env['PYPI_TOKEN'] === undefined && repoToken === '') {
-      logger.error(
-        'Token is not set. Either set PYPI_TOKEN environment variable or repoToken in plugin configuration',
-      );
-    }
     const result = publishPackage(
       srcDir,
       distDir,

--- a/lib/publish.ts
+++ b/lib/publish.ts
@@ -9,6 +9,8 @@ function publishPackage(
   srcDir: string,
   distDir: string,
   repoUrl: string,
+  repoUsername: string,
+  repoToken: string,
   gpgSign: boolean,
   gpgIdentity?: string,
   options?: Options,
@@ -37,10 +39,8 @@ function publishPackage(
       cwd: srcDir,
       env: {
         ...options?.env,
-        TWINE_USERNAME: process.env['PYPI_USERNAME']
-          ? process.env['PYPI_USERNAME']
-          : '__token__',
-        TWINE_PASSWORD: process.env['PYPI_TOKEN'],
+        TWINE_USERNAME: repoUsername,
+        TWINE_PASSWORD: repoToken,
       },
     },
   );
@@ -55,6 +55,8 @@ async function publish(pluginConfig: PluginConfig, context: Context) {
     gpgSign,
     gpgIdentity,
     repoUrl,
+    repoUsername,
+    repoToken,
     envDir,
   } = new DefaultConfig(pluginConfig);
 
@@ -65,10 +67,17 @@ async function publish(pluginConfig: PluginConfig, context: Context) {
 
   if (pypiPublish !== false) {
     logger.log(`Publishing package to ${repoUrl}`);
+    if (process.env['PYPI_TOKEN'] === undefined && repoToken === '') {
+      logger.error(
+        'Token is not set. Either set PYPI_TOKEN environment variable or repoToken in plugin configuration',
+      );
+    }
     const result = publishPackage(
       srcDir,
       distDir,
       process.env['PYPI_REPO_URL'] ?? repoUrl,
+      process.env['PYPI_USERNAME'] ?? repoUsername,
+      process.env['PYPI_TOKEN'] ?? repoToken,
       gpgSign,
       gpgIdentity,
       options,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,6 +2,8 @@ export interface PluginConfig {
   srcDir?: string;
   distDir?: string;
   repoUrl?: string;
+  repoUsername?: string;
+  repoToken?: string;
   pypiPublish?: boolean;
   gpgSign?: boolean;
   gpgIdentity?: string;

--- a/lib/verify.ts
+++ b/lib/verify.ts
@@ -90,22 +90,31 @@ function assertVersionCmd(pyproject: any, versionCmd?: string) {
 
 async function verify(pluginConfig: PluginConfig, context: Context) {
   const { logger } = context;
-  const { srcDir, setupPath, pypiPublish, repoUrl, versionCmd } =
-    new DefaultConfig(pluginConfig);
+  const {
+    srcDir,
+    setupPath,
+    pypiPublish,
+    repoUrl,
+    repoUsername,
+    repoToken,
+    versionCmd,
+  } = new DefaultConfig(pluginConfig);
 
   const execaOptions: Options = pipe(context);
 
   if (pypiPublish !== false) {
-    const username = process.env['PYPI_USERNAME']
-      ? process.env['PYPI_USERNAME']
-      : '__token__';
-    const token = process.env['PYPI_TOKEN'];
     const repo = process.env['PYPI_REPO_URL'] ?? repoUrl;
+    const username = process.env['PYPI_USERNAME'] ?? repoUsername;
+    const token = process.env['PYPI_TOKEN'] ?? repoToken;
 
-    assertEnvVar('PYPI_TOKEN');
+    if (token === '') {
+      throw new Error(
+        `Token is not set. Either set PYPI_TOKEN environment variable or repoToken in plugin configuration`,
+      );
+    }
 
     logger.log(`Verify authentication for ${username}@${repo}`);
-    await verifyAuth(repo, username, token!);
+    await verifyAuth(repo, username, token);
   }
 
   if (isLegacyBuildInterface(srcDir)) {

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -7,6 +7,8 @@ test('test DefaultConfig', async () => {
   expect(new DefaultConfig({}).srcDir).toBe('.');
   expect(new DefaultConfig({}).setupPath).toBe('setup.py');
   expect(new DefaultConfig({}).repoUrl).toBe('https://upload.pypi.org/legacy/');
+  expect(new DefaultConfig({}).repoUsername).toBe('__token__');
+  expect(new DefaultConfig({}).repoToken).toBe('');
   expect(new DefaultConfig({ distDir: 'mydist' }).distDir).toBe('mydist');
 });
 

--- a/test/util.ts
+++ b/test/util.ts
@@ -129,6 +129,8 @@ function genPluginArgs(config: PluginConfig) {
     distDir: config.distDir ?? `.tmp/${packageName}/dist`,
     envDir: config.envDir ?? `.tmp/${packageName}/.venv`,
     repoUrl: config.repoUrl ?? 'https://test.pypi.org/legacy/',
+    repoUsername: config.repoUsername ?? '__token__',
+    repoToken: config.repoToken ?? '',
   };
 
   const context: Context = {


### PR DESCRIPTION
To be able to push to multiple pypi repositories this PR allows `repoUsername` and `repoToken` parameters to be defined in the config file.

Environment variables always take priority.

README file is updated accordingly.

Let me know what you think