### PR TITLE
fix: remove --skip-existing flag due to unsupported in twine 6.2.0

### DIFF
--- a/lib/publish.ts
+++ b/lib/publish.ts
@@ -29,7 +29,6 @@ function publishPackage(
       '--repository-url',
       repoUrl,
       '--non-interactive',
-      '--skip-existing',
       '--verbose',
       ...signArgs,
       `${distDir}/*`,


### PR DESCRIPTION
Hello, 
twine 6.2.0 breaks upload due to unsupported feature `--skip-existing`

Having that, I see two options: freeze twine 6.1.0 or remove `--skip-existing` from `publish.ts`. The last one wins, see [twine 1264](https://github.com/pypa/twine/issues/1265) discussion